### PR TITLE
Support cmake-based installation of tattle.exe

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.15)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
+include(CMakePackageConfigHelpers)
+
 if (MSVC)
     add_compile_options(/MP)
     add_compile_options("/Zc:__cplusplus")
@@ -43,7 +45,7 @@ endif (WIN32)
 target_link_libraries(tattle PRIVATE wx::core wx::base wx::net)
 target_link_libraries(tattle PUBLIC nlohmann_json::nlohmann_json)
 
-target_include_directories(tattle PUBLIC "thirdparty/include")
+target_include_directories(tattle PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/thirdparty/include")
 
 
 
@@ -57,7 +59,21 @@ set_target_properties(tattle PROPERTIES
 	XCODE_SCHEME_ARGUMENTS "shared_config.json en-US.json error_report.json")
 
 
-# Install tattle binary
+# Install tattle binary and utility script
+set_property(TARGET tattle PROPERTY EXPORT_NAME tattle)
+install(
+    TARGETS tattle
+    EXPORT tattle-targets)
+install(
+    EXPORT tattle-targets
+    DESTINATION lib/cmake/tattle
+	NAMESPACE "tattle::")
+configure_package_config_file(
+    tattle-config.cmake.in
+    tattle-config.cmake
+    INSTALL_DESTINATION lib/cmake/tattle)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tattle-config.cmake DESTINATION lib/cmake/tattle)
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TattleUtil.cmake DESTINATION lib/cmake/tattle/util)
 install(TARGETS tattle DESTINATION bin)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,24 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
 
 # specify the C++ standard
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
-#set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+if (MSVC)
+    add_compile_options(/MP)
+    add_compile_options("/Zc:__cplusplus")
+endif()
 
-set(CMP0091 NEW)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+set(CMP0091 NEW) # Use modern policy for runtime library selection
 
 enable_language(CXX)
 enable_language(C)
 
 find_package (Threads)
+find_package(wxWidgets CONFIG REQUIRED) # Used for GUI and HTTPS
+find_package(nlohmann_json CONFIG REQUIRED) # Used for JSON parsing/writing
 
 
 # Library project
@@ -23,26 +30,35 @@ file(GLOB TATTLE_SOURCES src/*.cpp)
 
 add_executable(tattle WIN32 MACOSX_BUNDLE ${TATTLE_HEADERS} ${TATTLE_SOURCES})
 
+
 if (WIN32)
-	#set_property(TARGET tattle PROPERTY
-	#	MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
-		
+	#set_property(TARGET tattle PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 	#set(CMAKE_CXX_FLAGS_RELEASE ${CMAKE_CXX_FLAGS_RELEASE} "/MT")
 	#set(CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG} "/MTd")
-  
 	#target_link_libraries(tattle PRIVATE bufferoverflowU)
 endif (WIN32)
 
 
-#set(wxWidgets_STATIC ON)
-#set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "")
-#list(APPEND CMAKE_MODULE_PATH "$_VCPKG_ROOT_DIR/ports/wxWidgets/Modules")
-find_package(wxWidgets CONFIG REQUIRED)
-#target_link_libraries(tattle PUBLIC wxWidgets::wxWidgets)
-# target_include_directories(tattle PRIVATE ${wxWidgets_INCLUDE_DIRS})
+
 target_link_libraries(tattle PRIVATE wx::core wx::base wx::net)
+target_link_libraries(tattle PUBLIC nlohmann_json::nlohmann_json)
 
 target_include_directories(tattle PUBLIC "thirdparty/include")
+
+
+
+# Debugging configuration
+set_target_properties(tattle PROPERTIES
+	VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test"
+	VS_DEBUGGER_COMMAND_ARGUMENTS "shared_config.json en-US.json error_report.json")
+set_target_properties(tattle PROPERTIES 
+	XCODE_GENERATE_SCHEME TRUE
+	XCODE_SCHEME_WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}/test"
+	XCODE_SCHEME_ARGUMENTS "shared_config.json en-US.json error_report.json")
+
+
+# Install tattle binary
+install(TARGETS tattle DESTINATION bin)
 
 
 # Solution name
@@ -51,5 +67,4 @@ project(tattle)
 
 
 # Installation
-#install(TARGETS telling DESTINATION lib)
 #install(FILES ${TELLING_HEADERS} DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,8 +62,10 @@ set_target_properties(tattle PROPERTIES
 # Install tattle binary and utility script
 set_property(TARGET tattle PROPERTY EXPORT_NAME tattle)
 install(
-    TARGETS tattle
-    EXPORT tattle-targets)
+	TARGETS tattle
+	EXPORT tattle-targets
+	RUNTIME DESTINATION bin
+	BUNDLE DESTINATION bin)
 install(
     EXPORT tattle-targets
     DESTINATION lib/cmake/tattle
@@ -74,7 +76,6 @@ configure_package_config_file(
     INSTALL_DESTINATION lib/cmake/tattle)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tattle-config.cmake DESTINATION lib/cmake/tattle)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/TattleUtil.cmake DESTINATION lib/cmake/tattle/util)
-install(TARGETS tattle DESTINATION bin)
 
 
 # Solution name

--- a/cmake/TattleUtil.cmake
+++ b/cmake/TattleUtil.cmake
@@ -3,12 +3,18 @@
 # Copy tattle into the given directory.
 function(target_stage_tattle target)
     if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        # Copy tattle bundle into app bundle
         add_custom_command(TARGET ${target} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:tattle::tattle> $<TARGET_BUNDLE_CONTENT_DIR:${target}>
+            COMMAND ${CMAKE_COMMAND} -E copy_directory_if_different
+                "$<PATH:CMAKE_PATH,NORMALIZE,$<TARGET_FILE_DIR:tattle::tattle>/../../..>tattle.app"
+                "$<TARGET_BUNDLE_CONTENT_DIR:${target}>/Resources/tattle.app"
             COMMAND_EXPAND_LISTS)
     else()
+        # Copy tattle executable into binary directory
         add_custom_command(TARGET ${target} POST_BUILD
-            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:tattle::tattle> $<TARGET_FILE_DIR:${target}>
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "$<TARGET_FILE:tattle::tattle>"
+                "$<TARGET_FILE_DIR:${target}>"
             COMMAND_EXPAND_LISTS)
     endif()
 endfunction()

--- a/cmake/TattleUtil.cmake
+++ b/cmake/TattleUtil.cmake
@@ -1,0 +1,14 @@
+
+
+# Copy tattle into the given directory.
+function(target_stage_tattle target)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:tattle::tattle> $<TARGET_BUNDLE_CONTENT_DIR:${target}>
+            COMMAND_EXPAND_LISTS)
+    else()
+        add_custom_command(TARGET ${target} POST_BUILD
+            COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:tattle::tattle> $<TARGET_FILE_DIR:${target}>
+            COMMAND_EXPAND_LISTS)
+    endif()
+endfunction()

--- a/src/app.cpp
+++ b/src/app.cpp
@@ -337,7 +337,7 @@ bool TattleApp::OnInit()
 	// DEBUG: dump the config to CWD
 	if (report.config["path"].contains("config_dump"))
 	{
-		wxFile file(std::string(report.config["path"]["config_dump"]), wxFile::OpenMode::write);
+		wxFile file(wxString::FromUTF8(report.config["path"]["config_dump"]), wxFile::OpenMode::write);
 		if (!file.IsOpened()) return false;
 
 		file.Write(report.config.dump(1, '\t', false, nlohmann::detail::error_handler_t::replace));
@@ -347,7 +347,7 @@ bool TattleApp::OnInit()
 
 	if (report.config["path"].contains("state"))
 	{
-		bool loaded = persist.load(report.config["path"]["state"]);
+		bool loaded = persist.load(wxString::FromUTF8(report.config["path"]["state"]));
 	}
 
 	if (!report.url_post().isSet() && !report.url_query().isSet())

--- a/src/command_line.cpp
+++ b/src/command_line.cpp
@@ -138,7 +138,7 @@ namespace tattle
 #if TATTLE_LEGACY_COMMAND_LINE
 		case int('l'):
 			if (c1 == 0)
-				config["path"]["log"] = arg.GetStrVal();
+				config["path"]["log"] = std::string(arg.GetStrVal().ToUTF8());
 			else
 				err = CMD_ERR_UNKNOWN;
 			break;
@@ -461,7 +461,7 @@ namespace tattle
 
 			case int('d'): // -vd: review directory
 				config["gui"]["prompt"]["review"] = true;
-				config["path"]["review"] = arg.GetStrVal();
+				config["path"]["review"] = std::string(arg.GetStrVal().ToUTF8());
 				break;
 
 			default:

--- a/tattle-config.cmake.in
+++ b/tattle-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/util")
+
+include("${CMAKE_CURRENT_LIST_DIR}/tattle-targets.cmake" OPTIONAL)


### PR DESCRIPTION
These changes enable the tattle utility (binary or Mac app bundle) to be installed via cmake.  Also installed is a script that automates staging the utility alongside a downstream project's executable or within its Mac app bundle for debugging and deployment.